### PR TITLE
[INFRA-2270] Add fontconfig system package

### DIFF
--- a/jira/Dockerfile
+++ b/jira/Dockerfile
@@ -20,6 +20,7 @@ RUN \
     software-properties-common \
     curl \
     xmlstarlet \
+    fontconfig \
     sudo && \
   rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
According monitoring check, this package is required to correctly display captcha and other information
* Solution suggested by [this](https://confluence.atlassian.com/jirakb/health-check-fonts-965568867.html) 
* [Captcha](https://confluence.atlassian.com/jirakb/jira-ui-shows-unreadable-text-or-nothing-on-captcha-and-some-gadgets-due-to-missing-fonts-941590036.html)
* [INFRA-2270](https://issues.jenkins-ci.org/browse/INFRA-2270)